### PR TITLE
Using date to sort the order of posts

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,9 @@ import convertAsteriskToStrongTag from "@/utils/convertAsteriskToStrongTag";
 import presentation from "@/data/presentation";
 import projects from "@/data/projects";
 
-const posts = await getCollection("posts");
+const posts = (await getCollection("posts")).sort(function(first, second) {
+ return second.data.publishedAt - first.data.publishedAt;
+});
 ---
 
 <Layout>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -3,7 +3,9 @@ import { getCollection } from "astro:content";
 import Layout from "@/layouts/Layout.astro";
 import formatDate from "@/utils/formatDate";
 
-const posts = await getCollection("posts");
+const posts = (await getCollection("posts")).sort(function(first, second) {
+ return second.data.publishedAt - first.data.publishedAt;
+});
 ---
 
 <Layout title="Template - All Posts">


### PR DESCRIPTION
On the home and posts pages, the posts would show up in order of file number. 
Adding a new post would mean that all should be renamed by incrementing their index.

Using sort to display posts in order of latest to oldest.